### PR TITLE
Add basic unit test for chatbot response format

### DIFF
--- a/test_ai.py
+++ b/test_ai.py
@@ -63,3 +63,12 @@ predicted_label = model.predict(features_scaled)[0]
 
 predicted_career = label_encoder.inverse_transform([predicted_label])[0]
 print(f"🎯 Recommended Career: {predicted_career}")
+
+def test_dummy_response_format():
+    """
+    Dummy test to check that the chatbot returns a response in string format.
+    """
+    from chatbot import get_chat_response  # Update if function name differs
+    dummy_input = "What career is best for me?"
+    response = get_chat_response(dummy_input)
+    assert isinstance(response, str)


### PR DESCRIPTION
This pull request adds a simple test to validate that the chatbot response function returns a string.

-  Introduced test_dummy_response_format in test_ai.py  
-  Verifies that chatbot responses are returned in the correct format  
-  No changes to core functionality or behavior

This helps ensure basic reliability and prepares the ground for more advanced test coverage in the future